### PR TITLE
fix: iOS caching issue on lookup endpoint

### DIFF
--- a/ios/ExpoInAppUpdatesModule.swift
+++ b/ios/ExpoInAppUpdatesModule.swift
@@ -4,22 +4,23 @@ import StoreKit
 public class ExpoInAppUpdatesModule: Module {
     public func definition() -> ModuleDefinition {
         Name("ExpoInAppUpdates")
-        
+
         AsyncFunction("checkForUpdate") { (promise: Promise) in
             let appId = Bundle.main.infoDictionary?["AppStoreID"] as? String ?? ""
-            let appStoreURL = URL(string: "https://itunes.apple.com/lookup?id=\(appId)")!
-            
+            let timestamp = Date().timeIntervalSince1970
+            let appStoreURL = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&_=\(timestamp)")!
+
             URLSession.shared.dataTask(with: appStoreURL) { (data, response, error) in
                 if let error = error {
                     promise.reject("ERROR", "Failed to fetch app info: \(error.localizedDescription)")
                     return
                 }
-                
+
                 guard let data = data else {
                     promise.reject("ERROR", "No data received from App Store")
                     return
                 }
-                
+
                 do {
                     if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                        let results = json["results"] as? [[String: Any]],
@@ -35,20 +36,20 @@ public class ExpoInAppUpdatesModule: Module {
                 }
             }.resume()
         }
-        
+
         AsyncFunction("startUpdate") { (promise: Promise) in
             let appId = Bundle.main.infoDictionary?["AppStoreID"] as? String ?? ""
-            
+
             DispatchQueue.main.async {
                 guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                       let rootViewController = scene.windows.first?.rootViewController else {
                     promise.reject("ERROR", "Unable to get root view controller")
                     return
                 }
-                
+
                 let storeViewController = SKStoreProductViewController()
                 let parameters = [SKStoreProductParameterITunesItemIdentifier: appId]
-                
+
                 storeViewController.loadProduct(withParameters: parameters) { (loaded, error) in
                     if loaded {
                         DispatchQueue.main.async {


### PR DESCRIPTION
The `https://itunes.apple.com/lookup?id=<APP_ID>` is cached and it returns old app version on iOS, by appending a `timestamp` at the end of the url we make sure the `storeVersion` is always up to date.


closes https://github.com/SohelIslamImran/expo-in-app-updates/issues/6

