### PR TITLE
fix(ios): country restricted apps lookup fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ On Android, it will show a native overlay like the screenshots below but on iOS 
 npm install expo-in-app-updates
 ```
 
-For iOS, add your AppStoreID (the id in your app store link, e.g <https://apps.apple.com/pl/app/example/id1234567890>) in `infoPlist` in your `app.json`
+For iOS, add your AppStoreID (the id in your app store link, e.g <https://apps.apple.com/pl/app/example/id1234567890>) in `infoPlist` in your `app.json` / `app.config.js`.
+
+If your app is not available in the US, the default lookup might not find it. To fix this, you can set the `AppStoreCountry` to a country code where your app is available (e.g `pl` for Poland) in `infoPlist` in your `app.json` / `app.config.js`.
 
 ```json
 {
   "expo": {
     "ios": {
       "infoPlist": {
-        "AppStoreID": "1234567890"
+        "AppStoreID": "1234567890",
+        "AppStoreCountry": "pl" // Optional, only if the iTunes lookup used by this library doesn't find your app
       }
     }
   }

--- a/ios/ExpoInAppUpdatesModule.swift
+++ b/ios/ExpoInAppUpdatesModule.swift
@@ -7,8 +7,10 @@ public class ExpoInAppUpdatesModule: Module {
         
         AsyncFunction("checkForUpdate") { (promise: Promise) in
             let appId = Bundle.main.infoDictionary?["AppStoreID"] as? String ?? ""
+            let appStoreCountry = Bundle.main.infoDictionary?["AppStoreCountry"] as? String ?? ""
             let timestamp = Date().timeIntervalSince1970
-            let appStoreURL = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&_=\(timestamp)")!
+            let baseUrl = "https://itunes.apple.com/lookup?id=\(appId)&_=\(timestamp)"
+            let appStoreURL = URL(string: appStoreCountry.isEmpty ? baseUrl : "\(baseUrl)&country=\(appStoreCountry)")!
             let request = URLRequest(url: appStoreURL, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
             
             URLSession(configuration: .ephemeral).dataTask(with: request) { (data, response, error) in


### PR DESCRIPTION
Just a small fix to support apps that are mainly not available in the US, or restricted to few countries.

Tested on our apps.

Fixes #13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with instructions for setting `AppStoreCountry` in iOS configuration
	- Added guidance for specifying country code when app is not available in the US

- **New Features**
	- Enhanced App Store lookup flexibility by supporting country-specific app information retrieval

- **Improvements**
	- Added optional country parameter for more accurate iTunes app lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->