### PR TITLE
Feat: use PlayStore API's `updatePriority()` value as a default

### DIFF
--- a/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
+++ b/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
@@ -91,12 +91,21 @@ class ExpoInAppUpdatesModule : Module() {
             appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
                 when {
                     appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE -> {
+                        val updatePriority = appUpdateInfo.updatePriority()
+                        val updateTypeStr = when {
+                            updatePriority >= 4 -> {
+                                "IMMEDIATE"
+                            }
+                            else "FLEXIBLE"
+                        }
                         promise.resolve(mapOf(
                             "updateAvailable" to true,
                             "immediateAllowed" to appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE),
                             "flexibleAllowed" to appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE),
                             "daysSinceRelease" to appUpdateInfo.clientVersionStalenessDays(),
-                            "storeVersion" to appUpdateInfo.availableVersionCode().toString()
+                            "storeVersion" to appUpdateInfo.availableVersionCode().toString(),
+                            "serverPriority" to updatePriority,
+                            "serverUpdateType" to updateTypeStr
                         ))
                     }
                     appUpdateInfo.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS -> {
@@ -114,18 +123,39 @@ class ExpoInAppUpdatesModule : Module() {
             }
         }
 
-        AsyncFunction("startUpdate") { updateType: Int, promise: Promise ->
+        AsyncFunction("startUpdate") { updateType: Int?, promise: Promise ->
             val appUpdateInfoTask = appUpdateManager.appUpdateInfo
             appUpdateInfoTask.addOnSuccessListener { appUpdateInfo: AppUpdateInfo ->
-                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-                    && appUpdateInfo.isUpdateTypeAllowed(updateType)
-                ) {
+                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE) {
+                    var finalUpdateType: Int
+                    if (updateType != null) {
+                        if (!appUpdateInfo.isUpdateTypeAllowed(updateType)) {
+                            promise.resolve(false)
+                            return@addOnSuccessListener
+                        }
+                        finalUpdateType = updateType
+                    }
+                    else {
+                        // use a distributed priority when no value is specified
+                        val updatePriority = appUpdateInfo.updatePriority()
+                        val derived = if (updatePriority >= 4) AppUpdateType.IMMEDIATE else AppUpdateType.FLEXIBLE
+                        finalUpdateType = when {
+                            appUpdateInfo.isUpdateTypeAllowed(derived) -> derived
+                            // Optional graceful fallback order:
+                            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) -> AppUpdateType.FLEXIBLE
+                            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) -> AppUpdateType.IMMEDIATE
+                            else -> {
+                                promise.resolve(false)
+                                return@addOnSuccessListener
+                            }
+                        }
+                    }
                     // Send update start event
-                    val updateTypeName = if (updateType == AppUpdateType.FLEXIBLE) "FLEXIBLE" else "IMMEDIATE"
+                    val updateTypeName = if (finalUpdateType == AppUpdateType.FLEXIBLE) "FLEXIBLE" else "IMMEDIATE"
                     sendEvent(EVENT_UPDATE_START, mapOf("updateType" to updateTypeName))
 
                     appContext.currentActivity?.let { activity ->
-                        val appUpdateOptions = AppUpdateOptions.newBuilder(updateType)
+                        val appUpdateOptions = AppUpdateOptions.newBuilder(finalUpdateType)
                             .setAllowAssetPackDeletion(true)
                             .build()
 

--- a/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
+++ b/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
@@ -18,7 +18,8 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 
 class ExpoInAppUpdatesModule : Module() {
     private lateinit var appUpdateManager: AppUpdateManager
-    private val requestCode = 100
+    private const val requestCode = 100
+    private const val PRIORITY_THRESHOLD_IMMEDIATE = 4
 
     // Event constants
     companion object {
@@ -34,6 +35,21 @@ class ExpoInAppUpdatesModule : Module() {
             setPackage("com.android.vending")
         }
         appContext.currentActivity?.startActivity(intent)
+    }
+
+    private fun chooseFinalUpdateType(info: AppUpdateInfo, requested: Int?): Int? {
+        if (requested != null) {
+            return if (info.isUpdateTypeAllowed(requested)) requested else null
+        }
+        val priority = info.updatePriority()
+        val derived = if (priority >= PRIORITY_THRESHOLD_IMMEDIATE) AppUpdateType.IMMEDIATE else AppUpdateType.FLEXIBLE
+        return when {
+            info.isUpdateTypeAllowed(derived) -> derived
+            // Optional graceful fallback order:
+            info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) -> AppUpdateType.FLEXIBLE
+            info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) -> AppUpdateType.IMMEDIATE
+            else -> null
+        }
     }
 
     private val listener = InstallStateUpdatedListener { state ->
@@ -93,9 +109,7 @@ class ExpoInAppUpdatesModule : Module() {
                     appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE -> {
                         val updatePriority = appUpdateInfo.updatePriority()
                         val updateTypeStr = when {
-                            updatePriority >= 4 -> {
-                                "IMMEDIATE"
-                            }
+                            updatePriority >= PRIORITY_THRESHOLD_IMMEDIATE -> "IMMEDIATE"
                             else "FLEXIBLE"
                         }
                         promise.resolve(mapOf(
@@ -127,28 +141,10 @@ class ExpoInAppUpdatesModule : Module() {
             val appUpdateInfoTask = appUpdateManager.appUpdateInfo
             appUpdateInfoTask.addOnSuccessListener { appUpdateInfo: AppUpdateInfo ->
                 if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE) {
-                    var finalUpdateType: Int
-                    if (updateType != null) {
-                        if (!appUpdateInfo.isUpdateTypeAllowed(updateType)) {
-                            promise.resolve(false)
-                            return@addOnSuccessListener
-                        }
-                        finalUpdateType = updateType
-                    }
-                    else {
-                        // use a distributed priority when no value is specified
-                        val updatePriority = appUpdateInfo.updatePriority()
-                        val derived = if (updatePriority >= 4) AppUpdateType.IMMEDIATE else AppUpdateType.FLEXIBLE
-                        finalUpdateType = when {
-                            appUpdateInfo.isUpdateTypeAllowed(derived) -> derived
-                            // Optional graceful fallback order:
-                            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) -> AppUpdateType.FLEXIBLE
-                            appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) -> AppUpdateType.IMMEDIATE
-                            else -> {
-                                promise.resolve(false)
-                                return@addOnSuccessListener
-                            }
-                        }
+                    val finalUpdateType = chooseFinalUpdateType(appUpdateInfo, updateType)
+                    if (finalUpdateType == null) {
+                        promise.resolve(false)
+                        return@addOnSuccessListener
                     }
                     // Send update start event
                     val updateTypeName = if (finalUpdateType == AppUpdateType.FLEXIBLE) "FLEXIBLE" else "IMMEDIATE"

--- a/src/ExpoInAppUpdates.types.ts
+++ b/src/ExpoInAppUpdates.types.ts
@@ -43,6 +43,18 @@ export type ExpoInAppUpdatesModuleType = {
      * If able to start an [Immediate Update](https://developer.android.com/guide/playcore/in-app-updates/kotlin-java#immediate)
      * @platform android */
     immediateAllowed?: boolean;
+
+    /**
+     * Update priority received from Play Store
+     * @platform android
+     */
+    serverPriority?: number;
+
+    /**
+     * Update type calculated from serverPriority
+     * @platform android
+     */
+    serverUpdateType?: "FLEXIBLE" | "IMMEDIATE";
   }>;
 
   /**

--- a/src/ExpoInAppUpdates.types.ts
+++ b/src/ExpoInAppUpdates.types.ts
@@ -31,7 +31,7 @@ export type ExpoInAppUpdatesModuleType = {
      * If update is not available, or if staleness information is unavailable, this will be null.
      *
      * @platform android */
-    daysSinceRelease?: string | null;
+    daysSinceRelease?: number | null;
 
     /**
      * If able to start a [Flexible Update](https://developer.android.com/guide/playcore/in-app-updates/kotlin-java#flexible)

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,14 @@ export async function checkForUpdate() {
  *
  * @return Whether the update was started successfully.
  */
-export async function startUpdate(isImmediate = false) {
+export async function startUpdate(isImmediate?: boolean) {
   if (Platform.OS === "android") {
     return ExpoInAppUpdatesModule.startUpdate(
-      isImmediate ? AppUpdateType.IMMEDIATE : AppUpdateType.FLEXIBLE
+      isImmediate === undefined
+        ? undefined
+        : isImmediate
+          ? AppUpdateType.IMMEDIATE
+          : AppUpdateType.FLEXIBLE
     );
   }
   return ExpoInAppUpdatesModule.startUpdate();
@@ -54,7 +58,7 @@ export async function startUpdate(isImmediate = false) {
 export async function checkAndStartUpdate(isImmediate = false) {
   const { updateAvailable, immediateAllowed } = await checkForUpdate();
   if (updateAvailable) {
-    return startUpdate(isImmediate && immediateAllowed);
+    return startUpdate((isImmediate && immediateAllowed)? true : undefined);
   }
   return false;
 }


### PR DESCRIPTION
I modified the code to use an update priority received from PlayStore as a default, when the user leave `isImmediate` undefined.

`updatePriority()` method: https://developer.android.com/reference/com/google/android/play/core/appupdate/AppUpdateInfo?hl=ja#updatePriority()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically selects IMMEDIATE or FLEXIBLE updates on Android based on server priority when not explicitly requested.
  - checkForUpdate now returns serverPriority and serverUpdateType for better visibility into server recommendations.

- Improvements
  - startUpdate accepts an optional parameter, enabling a smarter, priority-driven update flow on Android.

- Breaking Changes
  - checkForUpdate: daysSinceRelease type changed from string to number.
  - TypeScript signature updates: startUpdate parameter is now optional; adjust usages accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->