### PR TITLE
fix(android): wrap startUpdateFlowForResult in try/catch to prevent SendIntentException crash

### DIFF
--- a/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
+++ b/android/src/main/java/expo/modules/inappupdates/ExpoInAppUpdatesModule.kt
@@ -3,6 +3,7 @@ package expo.modules.inappupdates
 import android.net.Uri
 import android.app.Activity
 import android.content.Intent
+import android.content.IntentSender
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -129,9 +130,18 @@ class ExpoInAppUpdatesModule : Module() {
                             .setAllowAssetPackDeletion(true)
                             .build()
 
-                        appUpdateManager.startUpdateFlowForResult(appUpdateInfo, activity, appUpdateOptions, requestCode)
-
-                        promise.resolve(true)
+                        try {
+                            appUpdateManager.startUpdateFlowForResult(appUpdateInfo, activity, appUpdateOptions, requestCode)
+                            promise.resolve(true)
+                        } catch (e: IntentSender.SendIntentException) {
+                            promise.reject(
+                                CodedException("Failed to start update flow (SendIntentException): ${e.message}", e)
+                            )
+                        } catch (e: Exception) {
+                            promise.reject(
+                                CodedException("Failed to start update flow: ${e.message}", e)
+                            )
+                        }
                     } ?: run {
                         promise.reject(CodedException("Current activity is null"))
                     }


### PR DESCRIPTION
## Summary

Wraps `appUpdateManager.startUpdateFlowForResult(...)` in a `try/catch` so that `IntentSender.SendIntentException` thrown by the Play Core App Update SDK becomes a promise rejection on the JS side instead of an uncaught crash.

A second `catch (Exception)` is added as a defensive net since `play-core` is closed-source and other unchecked throwables cannot be ruled out.

## Why

Google Play Console flagged this crash on production builds:

```
Caused by android.content.IntentSender$SendIntentException
    android.app.Activity.startIntentSenderForResultInner(Activity.java:6422)
    android.app.Activity.startIntentSenderForResult(Activity.java:6387)
    androidx.activity.ComponentActivity.startIntentSenderForResult(ComponentActivity.java:798)
    com.google.android.play.core.appupdate.zzf.startIntentSenderForResult(...)
    com.google.android.play.core.appupdate.zzg.startUpdateFlowForResult(...)
    expo.modules.inappupdates.ExpoInAppUpdatesModule$definition$1$4$1.invoke(ExpoInAppUpdatesModule.kt:95)
```

Per Google's own Play Console guidance for the Play Core App Update API:

> `startUpdateFlowForResult` is declared to throw `SendIntentException`, so wrap it in a try/catch.
> Don't cache or reuse `AppUpdateInfo`. Call `getAppUpdateInfo()` again every time you start the update flow.

The library already gets a fresh `AppUpdateInfo` on every `startUpdate` call, so the only missing piece is the `try/catch` around the launch itself.

The crash reproduces when the underlying `PendingIntent` has already been consumed — for example on rotation, on a second `startUpdate` call, or when the app returns from background — not just from rapid taps, so JS-side debouncing alone does not close it.

Same root cause as #20 and #21.

Fixes #24

## Test plan

- [ ] Run the app, trigger an in-app update; happy path still resolves the promise to `true`.
- [ ] Force the failure path (consume the `PendingIntent` and call `startUpdate` again) — promise rejects with a `CodedException` and the app no longer crashes.
- [ ] Verify Play Console no longer reports `SendIntentException` from `ExpoInAppUpdatesModule` after the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed in-app update process to properly handle and report errors to users, preventing silent failures during update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->