### PR TITLE
Bump minimum iOS version to 16.4 to align with Expo minimum version

### DIFF
--- a/ios/ExpoInAppUpdates.podspec
+++ b/ios/ExpoInAppUpdates.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms      = { :ios => '13.4' }
+  s.platforms      = { :ios => '16.4' }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/SohelIslamImran/expo-in-app-updates' }
   s.static_framework = true


### PR DESCRIPTION
iOS minimum version has been bumped from recently released expo 56

[Expo 56](https://docs.expo.dev/versions/v56.0.0/#support-for-android-and-ios-versions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum iOS version requirement from 13.4 to 16.4. Users on iOS 13.4-16.3 will no longer be able to install or update this app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SohelIslamImran/expo-in-app-updates/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->